### PR TITLE
small update to main Readme and add check for resid=0 in CG-itp

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ pip install ./
 ```
 pycgmap -f <.trr/.xtc/.gro/.pdb> -n <.ndx> -s <.tpr> -o <.xtc> -itp <.itp>
 ```
-the index file needs to be a mapping of the molecule to atomisitic coordinates and the itp file a full itp file with or without parameters. To generate both have a look at the follwing tool: https://github.com/marrink-lab/pycgbuilder
+the index file needs to be a mapping of the molecule to atomisitic coordinates and 
+the itp file needs to be a complete itp file of the CG with or without parameters. 
+To generate both have a look at the follwing tool: https://github.com/marrink-lab/pycgbuilder

--- a/pycgmap/mapping.py
+++ b/pycgmap/mapping.py
@@ -39,6 +39,10 @@ def create_mda_universe_from_itp(molecule):
     n_atoms = len(molecule.nodes)
     res_graph = make_residue_graph(molecule)
     node_to_attr = nx.get_node_attributes(molecule, "resid")
+    # a small primitive test checking whether the resid numbers are sensible - non-zero  positive integers. 
+    # here only a check for the non-zero part
+    if sorted(node_to_attr.keys())[0] < 1:
+        raise UserWarning("CG itp topology file contains erroneous residue numbers >resid<. \nHas to be non-zero, positive integer. Stopping.")
     atom_resindex = np.array([node_to_attr[node]-1 for node in sorted(node_to_attr.keys())])
     res_seg = np.array([ 1 for _ in res_graph.nodes])
 

--- a/pycgmap/mapping.py
+++ b/pycgmap/mapping.py
@@ -41,7 +41,7 @@ def create_mda_universe_from_itp(molecule):
     node_to_attr = nx.get_node_attributes(molecule, "resid")
     # a small primitive test checking whether the resid numbers are sensible - non-zero  positive integers. 
     # here only a check for the non-zero part
-    if sorted(node_to_attr.keys())[0] < 1:
+    if sorted(node_to_attr.values())[0] < 1:
         raise UserWarning("CG itp topology file contains erroneous residue numbers >resid<. \nHas to be non-zero, positive integer. Stopping.")
     atom_resindex = np.array([node_to_attr[node]-1 for node in sorted(node_to_attr.keys())])
     res_seg = np.array([ 1 for _ in res_graph.nodes])


### PR DESCRIPTION
I think some of the text benefited from clarifying a bit.

Also, we have found a thing with Petteri, which left the program hanging doing nothing. 
It is caused by the CG itp topology, which contained residue number `resid = 0` in the list of atoms. 

This is not a very useful value, changing it to 1 (the smallest assumed resid value in the code) fixed it.

Here I add a simple quick check for this possibility so that the user knows, whats wrong. 