### PR TITLE
vermouth based template

### DIFF
--- a/bin/ff_template
+++ b/bin/ff_template
@@ -1,0 +1,65 @@
+import argparse
+import pathlib
+import networkx as nx
+import cgsmiles
+import vermouth
+from vermouth.gmx.itp import write_molecule_itp
+from vermouth.forcefield import ForceField
+from vermouth.processors.do_links import _build_link_interaction_from
+from fast_forward.ff_template import read_ff_template
+from fast_forward.graph_utils import node_match
+
+def __main__():
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,)
+    parser.add_argument('-sketch', type=pathlib.Path, dest="input_file", help="input file")
+    parser.add_argument('-name', type=pathlib.Path, dest="molname", help="name of molecule")
+    parser.add_argument('-cgs', type=str, dest="cgsmiles_str", help="cgsmiles")
+
+    args = parser.parse_args()
+
+    # read the template file
+    ff = ForceField("new")
+    with open(args.input_file, "r") as _file:
+        lines = _file.readlines()
+
+    read_ff_template(lines, ff)
+
+    # read the molecule definition 
+#    elements = re.findall(r"\{[^\}]+\}", cgsmiles_str)
+    print(args.cgsmiles_str,)
+    _, mol_graph = cgsmiles.MoleculeResolver.from_string(args.cgsmiles_str, last_all_atom=False).resolve_all() 
+    for node in mol_graph.nodes:
+        mol_graph.nodes[node]['resname'] = mol_graph.nodes[node]['fragname']
+        mol_graph.nodes[node]['resid'] = mol_graph.nodes[node]['fragid'][0]
+
+    molecule = vermouth.Molecule(mol_graph, force_field=ff, nrexcl=1)
+    for block in ff.blocks.values():
+        GM = nx.isomorphism.GraphMatcher(molecule,
+                                         block,
+                                         node_match=node_match)
+        for match in GM.subgraph_isomorphisms_iter():
+            for target, origin in match.items():
+                 resid = molecule.nodes[target]["resid"]
+                 molecule.nodes[target].update(block.nodes[origin])
+                 molecule.nodes[target]["resid"] = resid
+            mapping = {origin: target for target, origin in match.items()}
+            for inter_type in block.interactions:
+                for inter in block.interactions[inter_type]:
+                    new_interaction = _build_link_interaction_from(molecule, 
+                                                                   inter,
+                                                                   mapping)
+                    molecule.interactions[inter_type].append(new_interaction)
+
+    # apply the template links
+    vermouth.processors.DoLinks().run_molecule(molecule)
+
+    header = ['initial itp generation done by Fast-Forward. Please cite:',
+              'https://zenodo.org/badge/latestdoi/327071500']
+
+    print(molecule.interactions)
+    # write the output 
+    with open(f'{args.molname}.itp', 'w') as fout:
+        write_molecule_itp(molecule, fout, moltype=args.molname, header=header)
+
+__main__()

--- a/fast_forward/ff_template.py
+++ b/fast_forward/ff_template.py
@@ -1,0 +1,64 @@
+import collections
+from vermouth.ffinput import FFDirector, _tokenize
+from vermouth.parser_utils import SectionLineParser
+
+class FFTemplate(FFDirector):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @SectionLineParser.section_parser('moleculetype', 'atoms')
+    def _block_atoms(self, line, lineno=0):
+        tokens = collections.deque(_tokenize(line))
+        _parse_template_atom(tokens, self.current_block)
+
+
+def _parse_template_atom(tokens, context):
+    if tokens[-1].startswith('{'):
+        attributes = _parse_atom_attributes(tokens.pop())
+    else:
+        attributes = {}
+
+    mass = None
+    charge = None
+    # we use the vermouth default way
+    if len(tokens) == 6:
+        # deque does not support slicing
+        first_six = (tokens.popleft() for _ in range(6))
+        _, atype, resid, resname, name, charge_group = first_six
+
+        # charge and mass are optional, but charge has to be defined for mass to be
+        if tokens:
+            charge = float(tokens.popleft())
+        if tokens:
+            mass = float(tokens.popleft())
+    # we have the reduced fromat
+    else:
+        name = tokens.popleft()
+        atype = tokens.popleft()
+        resname = context.name
+        resid = "1"
+        charge_group = "1"
+
+    if name in context:
+        msg = ('There is already an atom named "{}" in the block "{}". '
+               'Atom names must be unique within a block.')
+        raise IOError(msg.format(name, context.name))
+    atom = {
+        'atomname': name,
+        'atype': atype,
+        'resname': resname,
+        'resid': int(resid),
+        'charge_group': int(charge_group),
+    }
+    if mass:
+        atom['mass'] = mass
+    if charge:
+        atom['charge'] = charge
+
+    context.add_atom(dict(collections.ChainMap(attributes, atom)))
+
+def read_ff_template(lines, force_field):
+    director = FFTemplate(force_field)
+    return list(director.parse(iter(lines)))
+

--- a/fast_forward/graph_utils.py
+++ b/fast_forward/graph_utils.py
@@ -1,0 +1,21 @@
+import networkx as nx
+
+def find_one_ismags_match(graph1, graph2, node_match):
+    """
+    Returns one ismags match when graphs are isomorphic
+    otherwise None.
+    """
+    GM = nx.isomorphism.GraphMatcher(graph1, graph2, node_match=node_match)
+    raw_matches = GM.subgraph_isomorphisms_iter()
+    try:
+        mapping = next(raw_matches)
+        return mapping
+    except StopIteration:
+        raise IOError("no match_found")
+        return None
+
+def node_match(n1, n2):
+    for attr in ["resname", "atomname"]:
+        if n1[attr] != n2[attr]:
+            return False
+    return True


### PR DESCRIPTION
Summary
=======

This is a new template generation feature. It is build on the ideas by @csbrasnett. The idea is that the user provides a (simplified) ff file. Using the ff infrastructure we are sure that all interactions are handled, we can deal with annotations, and no extra code is introduced for parsing. To make the final itp file one also needs to provide a CGsmiles string. In the end ff_template is very similar to martinize2. It matches the link and blocks to the graph and then writes the itp. For most applications especially small molecules that is not need but it can handle complex polymers as well. Plus in principle the files should work for vermouth or polyply as well.

Example Benzene
==============
It is just one residue so we just have one block in links:
```
[ moleculetype ]
BENZ 1
[ atoms ]
TC5 R1
TC5 R2
TC5 R3
[ bonds ]
R1 R2
R2 R3
R1 R3
```  
We the call the template gen as:

```
ff_template -sketch benz.ff -name benzene -cgs "{[#BENZ]}.{[#R1]1[#R2][#R3]1}" 
```

Example Polystyrene
================
```
[ moleculetype ]
STYR 1
[ atoms ]
VNL TC3
R1 TC5
R2 TC5
R3 TC5
[ bonds ]
VNL R1
R1 R2
R2 R3
R1 R3
[ angles ]
VNL R1 R2
VNL R2 R3
[ link ]
[ bonds ]
VNL +VNL
[ link ]
[ angles ]
VNL +VNL ++VNL
```  
ff_template -sketch PS.ff -name PS -cgs "{[#STYR]|10}.{#STYR=[$][$][#VNL][#R1]1[#R2][#R3]1}" 
