### PR TITLE
add ff_assess

### DIFF
--- a/bin/ff_assess
+++ b/bin/ff_assess
@@ -19,46 +19,51 @@ VERSION = 'fast_forward version {}'.format(fast_forward.__version__)
 def hellinger(p,q):
     return np.round(np.sqrt(np.sum(np.power((np.sqrt(p) - np.sqrt(q)),2))) / np.sqrt(2),2)
 
-def report(h_score_dict, h_score, exclude_outliers=False):
-    buff = []
-    add = buff.append
 
-    input_len = output_len = 1
+def report(h_score_dict, exclude_outliers=False):
+    buff = ''
+
+    buff += " [ Interaction Distribution Report ]\n"
+    buff += f"   Overall Score : {{mean:.2f}} ± {{std:.2f}}\n\n"
+    buff += " Score guide:\n"
+    buff += "   0.0-0.3 : good\n"
+    buff += "   0.3-0.5 : ok\n"
+    buff += "   0.5-1.0 : bad\n"
+
     if exclude_outliers:
-        input_len = len(h_score)
-        h_score = np.array(h_score)[np.array(np.where(np.array(h_score)<0.5)[0], dtype=int)]
-        output_len = len(h_score)
+        buff += "\n\tNB: values over 0.5 have been excluded from the above summary value\n\n"
+    else:
+        buff += '\n'
 
-    add(" [ Interaction Distribution Report ]\n")
-    add("   Overall Score : {mean:.2f} ± {std:.2f}\n".format(mean=np.array(h_score).mean(),
-                                                             std=np.array(h_score).std()))
-    add(" Score guide:")
-    add("   0.0-0.3 : good")
-    add("   0.3-0.5 : ok")
-    add("   0.5-1.0 : bad")
-
-    if input_len != output_len:
-        add("\n   NB: values over 0.5 have been excluded from the above summary value\n")
-
-    add(" Interaction Scores:")
-    add(" 0 - identical, 1 - no overlap")
+    buff += " Interaction Scores:\n"
+    buff += " 0 - identical, 1 - no overlap\n\n"
+    h_score = []
     for interaction_type in h_score_dict.keys():
-        add(f" {interaction_type} ")
+        buff += f" {interaction_type} \n"
         for atom_group, score in h_score_dict[interaction_type].items():
-            if score < 0.5: # arbitrary cut off for now
-                add(f"\t{atom_group:20s}: {score:.2f}")
+            if exclude_outliers:
+                if score < 0.5:  # arbitrary cut off for now
+                    buff += f"\t{atom_group:20s}: {score:.2f}\n"
+                    h_score.append(score)
+                else:
+                    buff += f"\t{atom_group:20s}: {score:.2f} (excluded)\n"
             else:
-                add(f"\t{atom_group:20s}: {score:.2f} (excluded)")
+                buff += f"\t{atom_group:20s}: {score:.2f}\n"
+                h_score.append(score)
 
-    print('\n'.join(buff))
+    printable = buff.format(mean=np.array(h_score).mean(),
+                      std=np.array(h_score).std())
+
+    print(printable)
     with open('report.out', 'w') as fout:
-        fout.writelines('\n'.join(buff))
+        fout.writelines(printable)
 
 
 BINS_DICT = {"bonds": np.arange(0, 7, 0.01),
              "angles": np.arange(181),
              "dihedrals": np.arange(-180, 181)
              }
+
 
 def __main__():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,)
@@ -90,8 +95,6 @@ def __main__():
                 lines = _file.readlines()
         read_itp(lines, ff)
 
-        h_score = []
-
         h_score_dict = {'bonds': {},
                         'angles': {},
                         'dihedrals': {}}
@@ -107,7 +110,6 @@ def __main__():
                     reference_data = np.loadtxt([i for i in distribution_files if group_name in i and inter_type in i][0])
                     # calculate hellinger distance between simulated and reference distributions
                     score = hellinger(probs/probs.sum(), reference_data.T[1] / reference_data.T[1].sum())
-                    h_score.append(score)
                     h_score_dict[inter_type][group_name] = score
 
                     if args.plots:
@@ -128,7 +130,7 @@ def __main__():
                         fig.savefig(f'{inter_type}_{group_name}')
                         plt.close(fig)
 
-        report(h_score_dict, h_score, args.exclude_outliers)
+        report(h_score_dict, args.exclude_outliers)
 
 
 __main__()

--- a/bin/ff_assess
+++ b/bin/ff_assess
@@ -12,6 +12,7 @@ from fast_forward.compute_bonded import compute_value_for_interaction
 from fast_forward.itp_to_ag import itp_to_ag
 from fast_forward.itp_parser_sub import read_itp
 import matplotlib.pyplot as plt
+import pickle
 
 VERSION = 'fast_forward version {}'.format(fast_forward.__version__)
 
@@ -76,6 +77,8 @@ def __main__():
                         help="make plots comparing distributions")
     parser.add_argument('-outliers', default=False, action='store_true', dest='exclude_outliers',
                         help='exclude outliers from overall score')
+    parser.add_argument('-plot-data', default=False, action='store_true', dest="plot_data",
+                        help='save data for making plots as single pickle file')
 
     args = parser.parse_args()
 
@@ -87,6 +90,7 @@ def __main__():
     else:
         u = mda.Universe(args.trajfile, in_memory=True)
 
+    plot_data = {}
     # if itp file is provided use it
     if args.itp_files:
         ff = vermouth.forcefield.ForceField("dummy")
@@ -134,7 +138,14 @@ def __main__():
                         fig.savefig(f'{inter_type}_{group_name}')
                         plt.close(fig)
 
+                    if args.plot_data:
+                        plot_data[f'{inter_type}_{group_name}'] = {"x": reference_data.T[0],
+                                                                   "reference": reference_data.T[1],
+                                                                   'simulated': probs}
+
         report(h_score_dict, args.exclude_outliers)
 
+    if args.plot_data:
+        pickle.dump(plot_data, open('plot_data.p', 'wb'))
 
 __main__()

--- a/bin/ff_assess
+++ b/bin/ff_assess
@@ -33,6 +33,8 @@ def report(h_score_dict, h_score):
             add(f"\t{interaction_name:20s}: {score:.2f}")
 
     print('\n'.join(buff))
+    with open('report.out', 'w') as fout:
+        fout.writelines('\n'.join(buff))
 
 
 BINS_DICT = {"bonds": np.arange(0, 7, 0.01),

--- a/bin/ff_assess
+++ b/bin/ff_assess
@@ -11,6 +11,7 @@ import fast_forward
 from fast_forward.compute_bonded import compute_value_for_interaction
 from fast_forward.itp_to_ag import itp_to_ag
 from fast_forward.itp_parser_sub import read_itp
+import matplotlib.pyplot as plt
 
 VERSION = 'fast_forward version {}'.format(fast_forward.__version__)
 
@@ -18,19 +19,36 @@ VERSION = 'fast_forward version {}'.format(fast_forward.__version__)
 def hellinger(p,q):
     return np.round(np.sqrt(np.sum(np.power((np.sqrt(p) - np.sqrt(q)),2))) / np.sqrt(2),2)
 
-def report(h_score_dict, h_score):
+def report(h_score_dict, h_score, exclude_outliers=False):
     buff = []
     add = buff.append
 
+    input_len = output_len = 1
+    if exclude_outliers:
+        input_len = len(h_score)
+        h_score = np.array(h_score)[np.array(np.where(np.array(h_score)<0.5)[0], dtype=int)]
+        output_len = len(h_score)
+
     add(" [ Interaction Distribution Report ]\n")
     add("   Overall Score : {mean:.2f} ± {std:.2f}\n".format(mean=np.array(h_score).mean(),
-                                                             std =np.array(h_score).std()))
+                                                             std=np.array(h_score).std()))
+    add(" Score guide:")
+    add("   0.0-0.3 : good")
+    add("   0.3-0.5 : ok")
+    add("   0.5-1.0 : bad")
+
+    if input_len != output_len:
+        add("\n   NB: values over 0.5 have been excluded from the above summary value\n")
+
     add(" Interaction Scores:")
     add(" 0 - identical, 1 - no overlap")
     for interaction_type in h_score_dict.keys():
         add(f" {interaction_type} ")
-        for interaction_name, score in h_score_dict[interaction_type].items():
-            add(f"\t{interaction_name:20s}: {score:.2f}")
+        for atom_group, score in h_score_dict[interaction_type].items():
+            if score < 0.5: # arbitrary cut off for now
+                add(f"\t{atom_group:20s}: {score:.2f}")
+            else:
+                add(f"\t{atom_group:20s}: {score:.2f} (excluded)")
 
     print('\n'.join(buff))
     with open('report.out', 'w') as fout:
@@ -49,7 +67,10 @@ def __main__():
     parser.add_argument('-i', type=str, dest="itp_files", help="itp file", nargs='*')
     parser.add_argument('-d', type=str, dest='reference',
                         help="Path to directory with reference distributions")
-    parser.add_argument('-n', type=str, dest="ndx_file", help="index file")
+    parser.add_argument('-plots', default=False, action='store_true', dest="plots",
+                        help="make plots comparing distributions")
+    parser.add_argument('-outliers', default=False, action='store_true', dest='exclude_outliers',
+                        help='exclude outliers from overall score')
 
     args = parser.parse_args()
 
@@ -82,17 +103,32 @@ def __main__():
                     time_series = compute_value_for_interaction(u, inter_type, pair_idxs)
                     # calculate simulation distribution
                     probs, edges = np.histogram(time_series, density=True, bins=BINS_DICT[inter_type])
-                    center_points = edges[:-1] + np.diff(edges)/2.
-                    distr = np.transpose((center_points, probs))
-
+                    # read in reference distribution
                     reference_data = np.loadtxt([i for i in distribution_files if group_name in i and inter_type in i][0])
-
+                    # calculate hellinger distance between simulated and reference distributions
                     score = hellinger(probs/probs.sum(), reference_data.T[1] / reference_data.T[1].sum())
                     h_score.append(score)
-
                     h_score_dict[inter_type][group_name] = score
 
-        report(h_score_dict, h_score)
+                    if args.plots:
+                        # make a plot to compare the distributions
+                        fig, ax = plt.subplots()
+                        ax.plot(reference_data.T[0],
+                                reference_data.T[1],
+                                c='#4E63F5',
+                                label='Reference',
+                                )
+                        ax.plot(reference_data.T[0],
+                                probs,
+                                c='#F54E5D',
+                                label='Simulation',
+                                )
+                        ax.set_title(f'{" ".join([str(i + 1) for i in pair_idxs])} {inter_type[:-1]}')
+                        ax.legend()
+                        fig.savefig(f'{inter_type}_{group_name}')
+                        plt.close(fig)
+
+        report(h_score_dict, h_score, args.exclude_outliers)
 
 
 __main__()

--- a/bin/ff_assess
+++ b/bin/ff_assess
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Main exe for scoring simulations against mapped trajectories
+"""
+import argparse
+from glob import glob
+import numpy as np
+import MDAnalysis as mda
+import vermouth.forcefield
+import fast_forward
+from fast_forward.compute_bonded import compute_value_for_interaction
+from fast_forward.itp_to_ag import itp_to_ag
+from fast_forward.itp_parser_sub import read_itp
+
+VERSION = 'fast_forward version {}'.format(fast_forward.__version__)
+
+
+def hellinger(p,q):
+    return np.round(np.sqrt(np.sum(np.power((np.sqrt(p) - np.sqrt(q)),2))) / np.sqrt(2),2)
+
+def report(h_score_dict, h_score):
+    buff = []
+    add = buff.append
+
+    add(" [ Interaction Distribution Report ]\n")
+    add("   Overall Score : {mean:.2f} ± {std:.2f}\n".format(mean=np.array(h_score).mean(),
+                                                             std =np.array(h_score).std()))
+    add(" Interaction Scores:")
+    add(" 0 - identical, 1 - no overlap")
+    for interaction_type in h_score_dict.keys():
+        add(f" {interaction_type} ")
+        for interaction_name, score in h_score_dict[interaction_type].items():
+            add(f"\t{interaction_name:20s}: {score:.2f}")
+
+    print('\n'.join(buff))
+
+
+BINS_DICT = {"bonds": np.arange(0, 7, 0.01),
+             "angles": np.arange(181),
+             "dihedrals": np.arange(-180, 181)
+             }
+
+def __main__():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,)
+    parser.add_argument('-f', type=str, dest="trajfile", help="simulated trajectory file")
+    parser.add_argument('-s', type=str, dest="tprfile", help="simulated tpr file", default=None)
+    parser.add_argument('-i', type=str, dest="itp_files", help="itp file", nargs='*')
+    parser.add_argument('-d', type=str, dest='reference',
+                        help="Path to directory with reference distributions")
+    parser.add_argument('-n', type=str, dest="ndx_file", help="index file")
+
+    args = parser.parse_args()
+
+    distribution_files = glob(f'{args.reference}/*distr.dat')
+
+    # load trajectory
+    if args.tprfile:
+        u = mda.Universe(args.tprfile, args.trajfile, in_memory=True)
+    else:
+        u = mda.Universe(args.trajfile, in_memory=True)
+
+    # if itp file is provided use it
+    if args.itp_files:
+        ff = vermouth.forcefield.ForceField("dummy")
+        for file_handle in args.itp_files:
+            with open(file_handle) as _file:
+                lines = _file.readlines()
+        read_itp(lines, ff)
+
+        h_score = []
+
+        h_score_dict = {'bonds': {},
+                        'angles': {},
+                        'dihedrals': {}}
+        # loop over molecules
+        for molname, block in ff.blocks.items():
+            interaction_groups = itp_to_ag(block, molname, u)
+            for inter_type in ['bonds', 'angles', 'dihedrals']:
+                for group_name, pair_idxs in interaction_groups[inter_type].items():
+                    time_series = compute_value_for_interaction(u, inter_type, pair_idxs)
+                    # calculate simulation distribution
+                    probs, edges = np.histogram(time_series, density=True, bins=BINS_DICT[inter_type])
+                    center_points = edges[:-1] + np.diff(edges)/2.
+                    distr = np.transpose((center_points, probs))
+
+                    reference_data = np.loadtxt([i for i in distribution_files if group_name in i and inter_type in i][0])
+
+                    score = hellinger(probs/probs.sum(), reference_data.T[1] / reference_data.T[1].sum())
+                    h_score.append(score)
+
+                    h_score_dict[inter_type][group_name] = score
+
+        report(h_score_dict, h_score)
+
+
+__main__()

--- a/bin/ff_assess
+++ b/bin/ff_assess
@@ -11,8 +11,8 @@ import fast_forward
 from fast_forward.compute_bonded import compute_value_for_interaction
 from fast_forward.itp_to_ag import itp_to_ag
 from fast_forward.itp_parser_sub import read_itp
-import matplotlib.pyplot as plt
-import pickle
+from fast_forward.interaction_plots import make_distribution_plot
+from collections import defaultdict
 
 VERSION = 'fast_forward version {}'.format(fast_forward.__version__)
 
@@ -90,7 +90,7 @@ def __main__():
     else:
         u = mda.Universe(args.trajfile, in_memory=True)
 
-    plot_data = {}
+    plot_data = defaultdict(dict)
     # if itp file is provided use it
     if args.itp_files:
         ff = vermouth.forcefield.ForceField("dummy")
@@ -120,32 +120,11 @@ def __main__():
                     score = hellinger(probs/probs.sum(), reference_data.T[1] / reference_data.T[1].sum())
                     h_score_dict[inter_type][group_name] = score
 
-                    if args.plots:
-                        # make a plot to compare the distributions
-                        fig, ax = plt.subplots()
-                        ax.plot(reference_data.T[0],
-                                reference_data.T[1],
-                                c='#4E63F5',
-                                label='Reference',
-                                )
-                        ax.plot(reference_data.T[0],
-                                probs,
-                                c='#F54E5D',
-                                label='Simulation',
-                                )
-                        ax.set_title(f'{" ".join([str(i + 1) for i in pair_idxs])} {inter_type[:-1]}')
-                        ax.legend()
-                        fig.savefig(f'{inter_type}_{group_name}')
-                        plt.close(fig)
-
-                    if args.plot_data:
-                        plot_data[f'{inter_type}_{group_name}'] = {"x": reference_data.T[0],
-                                                                   "reference": reference_data.T[1],
-                                                                   'simulated': probs}
-
+                    plot_data[inter_type][group_name] = {"x": reference_data.T[0],
+                                                         "Reference": reference_data.T[1],
+                                                         'Simulated': probs}
+        if args.plots:
+            make_distribution_plot(plot_data, args.plot_data)
         report(h_score_dict, args.exclude_outliers)
-
-    if args.plot_data:
-        pickle.dump(plot_data, open('plot_data.p', 'wb'))
 
 __main__()

--- a/bin/ff_assess
+++ b/bin/ff_assess
@@ -107,7 +107,11 @@ def __main__():
                     # calculate simulation distribution
                     probs, edges = np.histogram(time_series, density=True, bins=BINS_DICT[inter_type])
                     # read in reference distribution
-                    reference_data = np.loadtxt([i for i in distribution_files if group_name in i and inter_type in i][0])
+                    try:
+                        reference_data = np.loadtxt([i for i in distribution_files if group_name in i and inter_type in i][0])
+                    except IndexError:
+                        print(f"{group_name} file not found!")
+                        continue
                     # calculate hellinger distance between simulated and reference distributions
                     score = hellinger(probs/probs.sum(), reference_data.T[1] / reference_data.T[1].sum())
                     h_score_dict[inter_type][group_name] = score

--- a/bin/ff_inter
+++ b/bin/ff_inter
@@ -40,7 +40,8 @@ def __main__():
     parser.add_argument('-pref', type=str, dest="prefix", help="common prefix to filename", default="")
     parser.add_argument('-i', type=str, dest="itp_files", help="itp file", nargs='*')
     parser.add_argument('-dists', default=False, action='store_true',
-                        dest="distribution_data", help="Save text files with time series and distribution data for interactions")
+                        dest="distribution_data",
+                        help="Save text files with time series and distribution data for interactions")
     parser.add_argument('-plots', default=False, action="store_true",
                         dest="plots", help="Save the fits of bonded interactions")
     parser.add_argument('-plot-data', default=False, action="store_true",
@@ -105,12 +106,13 @@ def __main__():
 
             # make plots if we want to
             if args.plots:
-                make_distribution_plot(fitter.fit_parameters,
+                make_distribution_plot(fitter.plot_parameters,
                                        args.plot_data)
 
             # write out the itp
             itp_writer(molname,
-                       ff.blocks[molname], command_used=' '.join(sys.argv),
+                       ff.blocks[molname],
+                       command_used=' '.join(sys.argv),
                        )
 
     # write out using DeferredFileWriter to back up any existing files of the same names

--- a/fast_forward/interaction_fit.py
+++ b/fast_forward/interaction_fit.py
@@ -5,6 +5,7 @@ functions for fitting interaction distributions
 
 import numpy as np
 from lmfit.models import GaussianModel
+from lmfit import Parameters
 from MDAnalysis.units import constants
 import lmfit
 from collections import defaultdict
@@ -42,6 +43,16 @@ def _gaussian_fitter(x, y, initial_center, initial_sigma, initial_amplitude):
 
     return gaussian_result
 
+def _gaussian_generator(x, params):
+
+    mod = GaussianModel(x=x)
+    pars = Parameters()
+    pars.add("center", params['center'].value)
+    pars.add("sigma", params['sigma'].value)
+    pars.add("amplitude", params['amplitude'].value)
+    fitted_distribution = mod.eval(pars, x=x)
+
+    return fitted_distribution
 
 class InteractionFitter:
     """
@@ -71,6 +82,7 @@ class InteractionFitter:
         # this will store the interactions
         self.interactions_dict = defaultdict(list)
         self.fit_parameters = defaultdict(dict)
+        self.plot_parameters = defaultdict(dict)
 
     def _bonds_fitter(self, data, group_name):
         """
@@ -98,9 +110,12 @@ class InteractionFitter:
         center = np.round(initial_center / 10, self.precision)
         sigma = np.round((self.kb * self.temperature) / ((initial_sigma / 10) ** 2), self.precision)
 
-        self.fit_parameters['bonds'][group_name] = {'data': data,
-                                                    'distribution_params': [center, sigma],
-                                                    'fit_params': [center, initial_sigma]}
+        self.fit_parameters['bonds'][group_name] = [center, sigma]
+
+        self.plot_parameters['bonds'][group_name] = {'x': x,
+                                                     'Distribution': y,
+                                                     'Fitted': _gaussian_generator(x,
+                                                                                   gaussian_fit.params)}
 
     def _angles_fitter(self, data, group_name):
         """
@@ -115,8 +130,12 @@ class InteractionFitter:
         """
         x, y = data.T
         gaussian_fit = _gaussian_fitter(x, y,
-                                        initial_center=dict(value=x[y.argmax()], min=x[y.argmax()] - 20, max=x[y.argmax()] + 20),
-                                        initial_sigma=dict(value=x.std(), min=x.std() / 4, max=x.std() * 1.5),
+                                        initial_center=dict(value=x[y.argmax()],
+                                                            min=x[y.argmax()] - 20,
+                                                            max=x[y.argmax()] + 20),
+                                        initial_sigma=dict(value=x.std(),
+                                                           min=x.std() / 4,
+                                                           max=x.std() * 1.5),
                                         initial_amplitude=dict(value=y.max(), min=0)
                                         )
 
@@ -128,9 +147,11 @@ class InteractionFitter:
         var = np.deg2rad(initial_sigma) ** 2
         sigma = np.round((self.kb * self.temperature) / (sin_term * var), self.precision)
 
-        self.fit_parameters['angles'][group_name] = {'data': data,
-                                                     'distribution_params': [center, sigma],
-                                                     'fit_params': [center, initial_sigma]}
+        self.fit_parameters['angles'][group_name] = [center, sigma]
+
+        self.plot_parameters['angles'][group_name] = {'x': x,
+                                                     'Distribution': y,
+                                                     'Fitted': _gaussian_generator(x, gaussian_fit.params)}
 
     # Fitting function for proper dihedrals
     def _proper_dihedral_model_function(self, params, x):
@@ -242,9 +263,12 @@ class InteractionFitter:
                 x0 = best_params[f'x0_{i}'].value
                 n = int(best_params[f'n{i}'].value)  # Ensure n is integer
                 pars_out.append([best_params[f'k{i}'].value, x0, n])
-            self.fit_parameters['dihedrals'][group_name] = {'data': data,
-                                                            'distribution_params': {i: j for i, j in enumerate(pars_out)},
-                                                            'fit_params': pars_out}
+            self.fit_parameters['dihedrals'][group_name] = {i: j for i, j in enumerate(pars_out)}
+
+            self.plot_parameters['dihedrals'][group_name] = {'x': np.degrees(x),
+                                                             'Distribution': y,
+                                                             'Fitted': self._proper_dihedral_model_function(best_params,
+                                                                                                            x)}
 
         else:
             # transform the centre back into the correct domain after fitting to account for periodicity.
@@ -253,16 +277,18 @@ class InteractionFitter:
             center = np.round(c0, self.precision)
             sigma = np.round((self.kb * self.temperature) / ((gaussian_result.params['sigma']) ** 2), self.precision)
 
-            self.fit_parameters['dihedrals'][group_name] = {'data': data,
-                                                            'distribution_params': [center, sigma],
-                                                            'fit_params': {'amp': gaussian_result.params['amplitude'],
-                                                                           'center': gaussian_result.params['center'],
-                                                                           'sigma': gaussian_result.params['sigma']}}
+            self.fit_parameters['dihedrals'][group_name] = [center, sigma]
+
+            x_plot = np.degrees((x+(2*np.pi)) % (2*np.pi) - np.pi)
+            fitted_improper_plot = _gaussian_generator(x, gaussian_result.params)[np.argsort(x_plot)]
+            self.plot_parameters['dihedrals'][group_name] = {'x': x_plot,
+                                                             'Distribution': y,
+                                                             'Fitted': fitted_improper_plot}
 
     def fit_to_gmx(self, inter_type, group_name, atoms):
 
         if inter_type == 'bonds':
-            parameters = self.fit_parameters['bonds'][group_name]['distribution_params']
+            parameters = self.fit_parameters['bonds'][group_name]
             center, sigma = parameters
 
             if sigma < self.constraint_converter:
@@ -278,7 +304,7 @@ class InteractionFitter:
                                                                          meta={"ifndef": "FLEXIBLE",
                                                                                "comment": group_name}))
         elif inter_type == 'angles':
-            parameters = self.fit_parameters['angles'][group_name]['distribution_params']
+            parameters = self.fit_parameters['angles'][group_name]
             center, sigma = parameters
 
             # empirically derived. if sigma too big, angles get very unstable.
@@ -297,7 +323,7 @@ class InteractionFitter:
 
         elif inter_type == 'dihedrals':
 
-            parameters = self.fit_parameters['dihedrals'][group_name]['distribution_params']
+            parameters = self.fit_parameters['dihedrals'][group_name]
             if isinstance(parameters, list):
                 center, sigma = parameters
                 center = np.round(np.degrees(center), self.precision)

--- a/fast_forward/interaction_plots.py
+++ b/fast_forward/interaction_plots.py
@@ -1,160 +1,29 @@
 
-
-
 '''
 Functions for plotting fitted interaction distributions
 '''
 
 import matplotlib.pyplot as plt
-from lmfit.models import GaussianModel
-from lmfit import Parameters
-import numpy as np
 import pickle
+from .interaction_distribution import BINS_DICT
 
-def _bond_plot(data, fit_params, atom_list, ax):
-    '''
-    plot a bonded distribution and the fit
-    '''
+X_LABELS={'bonds': 'Distance',
+          'angles': 'Angle',
+          'dihedrals': 'Angle'}
 
-    x = data.T[0]
-    y = data.T[1]
+def _plotter(data, atom_list, inter_type, ax):
 
-    mod = GaussianModel(x=x)
-    pars = Parameters()
-    pars.add("center", fit_params[0]*10) #convert back to A
-    pars.add("sigma", fit_params[1])
-    fitted_distribution = mod.eval(pars,x=x)
-
-    ax.plot(x, y, c='#6970E0', label='Distribution')
-    ax.plot(x, fitted_distribution, c='#E06B69', label='Fit')
-
-    curr_lims = ax.get_ylim()
-    ax.set_ylim(0, curr_lims[1] + (curr_lims[1] * 0.1))
-
-    ax.axvline(fit_params[0]*10, c='#506155', label=f"Center = {fit_params[0]*10: .2f}")
-    ax.fill_between(np.linspace(fit_params[0]*10 - fit_params[1],
-                                fit_params[0]*10 + fit_params[1],
-                                100),
-                    curr_lims[1] + (curr_lims[1] * 0.1),
-                    color='#506155',
-                    alpha=0.35,
-                    label=f"Sigma = {fit_params[1]: .2f}")
-
+    cols = ['#6970E0', '#E06B69']
+    needed_keys = [key for key in list(data.keys()) if key != 'x']
+    for idx, key in enumerate(needed_keys):
+        ax.plot(data['x'],
+                data[key],
+                c = cols[idx],
+                label=key)
     ax.legend()
-    ax.set_title(f'{atom_list} bond')
-    ax.set_xlabel('Distance')
-
-    data_out = {ax.get_xlabel(): x,
-                'simulated_distribution': y,
-                'fitted_distribution': fitted_distribution,
-                'distribution_center': fit_params[0],
-                'distribution_sigma': fit_params[1]
-                }
-    return data_out
-
-def _angles_plot(data, fit_params, atom_list, ax, ):
-    '''
-    plot an angle distribution and the fit
-    '''
-
-    x = data.T[0]
-    y = data.T[1]
-
-    mod = GaussianModel(x=x)
-    pars = Parameters()
-    pars.add("center", fit_params[0])
-    pars.add("sigma", fit_params[1])
-    fitted_distribution = mod.eval(pars, x=x)
-
-    ax.plot(x, y, c='#6970E0', label='Distribution')
-    ax.plot(x, fitted_distribution, c='#E06B69', label='Fit')
-
-    curr_lims = ax.get_ylim()
-    ax.set_ylim(0, curr_lims[1] + (curr_lims[1] * 0.1))
-    ax.set_xlim(0, 180)
-
-    ax.axvline(fit_params[0], c='#506155', label=f"Center = {fit_params[0]: .2f}")
-    ax.fill_between(np.linspace(fit_params[0] - fit_params[1],
-                                fit_params[0] + fit_params[1],
-                                100),
-                    curr_lims[1] + (curr_lims[1] * 0.1),
-                    color='#506155',
-                    alpha=0.35,
-                    label=f"Sigma = {fit_params[1]: .2f}")
-
-    ax.legend()
-    ax.set_title(f'{atom_list} angle')
-    ax.set_xlabel('Angle')
-
-    data_out = {ax.get_xlabel(): x,
-                'simulated_distribution': y,
-                'fitted_distribution': fitted_distribution,
-                'distribution_center': fit_params[0],
-                'distribution_sigma': fit_params[1]
-                }
-    return data_out
-
-def _proper_dihedrals_plot(data, fit_params, atom_list, ax):
-    '''
-    plot a proper dihedral distribution and the fit
-    '''
-    x = np.linspace(-np.pi, np.pi, 360)
-    y = data.T[1]
-    y_fitted = np.zeros_like(x)
-    for inter in fit_params:
-        k, theta, n = inter
-        angle_rad = theta
-        y_fitted += k * (1 + np.cos(n*x - angle_rad))
-
-    ax.plot(np.degrees(x), y, c='#6970E0', label='Distribution')
-    ax.plot(np.degrees(x), y_fitted, c='#E06B69', label='Fit')
-
-    ax.set_xlim(-180, 180)
-
-    ax.legend()
-    ax.set_title(f'{atom_list} dihedral')
-    ax.set_xlabel('Angle')
-
-    data_out = {ax.get_xlabel(): np.degrees(x),
-                'simulated_distribution': y,
-                'fitted_distribution': y_fitted,
-                }
-    return data_out
-
-
-def _improper_dihedrals_plot(data, fit_params, atom_list, ax):
-    '''
-    plot an improper dihedral distribution and the fit
-    '''
-    x = np.linspace(-np.pi, np.pi, 360)
-    y = data.T[1]
-
-    mod = GaussianModel(x=x)
-    pars = Parameters()
-
-    pars.add("amplitude", value=fit_params['amp'])
-    pars.add("center", value=fit_params['center'])
-    pars.add("sigma", value=fit_params['sigma'])
-    fitted_distribution = mod.eval(pars, x=x)
-
-    x_plot = (x+(2*np.pi)) % (2*np.pi) - np.pi
-
-    ax.plot(np.degrees(x), y, c='#6970E0', label='Distribution')
-    ax.plot(np.degrees(x_plot)[np.argsort(x_plot)],
-            fitted_distribution[np.argsort(x_plot)], c='#E06B69', label='Fit')
-
-    ax.set_xlim(-180, 180)
-
-    ax.legend()
-    ax.set_title(f'{atom_list} dihedral')
-    ax.set_xlabel('Angle')
-
-
-    data_out = {ax.get_xlabel(): np.degrees(x),
-                'simulated_distribution': y,
-                'fitted_distribution': fitted_distribution[np.argsort(x_plot)],
-                }
-    return data_out
+    ax.set_title(f'{atom_list} {inter_type}')
+    ax.set_xlim(BINS_DICT[inter_type][0], BINS_DICT[inter_type][-1])
+    ax.set_xlabel(X_LABELS[inter_type])
 
 def make_distribution_plot(fit_data, save_plot_data=False, axarr=None):
     '''
@@ -179,27 +48,13 @@ def make_distribution_plot(fit_data, save_plot_data=False, axarr=None):
                                figsize=(ncols*4, nrows*4))
 
     count = 0
-    all_plot_data = {}
     for interaction_type in fit_data.keys():
-        all_plot_data[interaction_type] = {}
         for atom_list in fit_data[interaction_type].keys():
-            data = fit_data[interaction_type][atom_list]['data']
-            fitted_parameters = fit_data[interaction_type][atom_list]['fit_params']
-            ax = axarr.flatten()[count]
-            if interaction_type == 'bonds':
-                plot_data = _bond_plot(data, fitted_parameters, atom_list, ax)
-            elif interaction_type == 'angles':
-                plot_data = _angles_plot(data, fitted_parameters, atom_list, ax)
-            elif interaction_type == 'dihedrals':
-                if isinstance(fitted_parameters, list):
-                    plot_data = _proper_dihedrals_plot(data, fitted_parameters, atom_list, ax)
-                else:
-                    plot_data = _improper_dihedrals_plot(data, fitted_parameters, atom_list, ax)
+            _plotter(fit_data[interaction_type][atom_list], atom_list, interaction_type, axarr.flatten()[count])
             count += 1
-            all_plot_data[interaction_type][atom_list] = plot_data
 
     if save_plot_data:
-        pickle.dump(all_plot_data, open('plot_data.p', 'wb'))
+        pickle.dump(fit_data, open('plot_data.p', 'wb'))
 
     # remove unused axes
     for ax in axarr.flatten()[count:]:

--- a/fast_forward/itp_parser_sub.py
+++ b/fast_forward/itp_parser_sub.py
@@ -43,7 +43,11 @@ class FastForwardITPParser(ITPDirector):
         lineno = 0
         for lineno, line in enumerate(file_handle, 1):
             line, comment = split_comments(line, self.COMMENT_CHAR)
-            self.current_comment = comment
+            if self.COMMENT_CHAR in comment:
+                atom_comment, _ = split_comments(comment, self.COMMENT_CHAR)
+                self.current_comment = atom_comment
+            else:
+                self.current_comment = comment
             if not line:
                 continue
             result = self.dispatch(line)(line, lineno)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ def package_files(directory):
 setup(
 #    package_data={'': package_files('pycgmap/data')
 #                  + package_files('polyply/tests/test_data'),},
-    scripts=['bin/ff_map', 'bin/ff_inter'],
+    scripts=['bin/ff_map', 'bin/ff_inter', 'bin/ff_assess'],
     pbr=True,
 )


### PR DESCRIPTION
ff_assess (can change name) is a small tool to compare the interaction distributions between a simulated trajectory and mapped distributions.

Here `-f` and `-s` are used to read the input simulated trajectory, while `-d` points to a directory where the output distributions of the `ff_inter` program are found. `ff_assess` then simply calculates the hellinger distance between the simulated and reference distributions to produce a single score for the faithfulness between the simulated and mapped trajectories.

Certainly needs a bit of tidying re: other PRs open atm