### PR TITLE
retain uncommented interactions

### DIFF
--- a/bin/ff_inter
+++ b/bin/ff_inter
@@ -85,7 +85,7 @@ def __main__():
             # calculate distributions for interaction
             if not args.itp_only:
                 guess_interactions(block)
-            interaction_groups = itp_to_ag(block, molname, u)
+            interaction_groups, remainders = itp_to_ag(block, molname, u)
             distributions = {"bonds": {}, "angles": {}, "dihedrals": {}}
             for inter_type in ['bonds', 'angles', 'dihedrals']:
                 for group_name, pair_idxs in interaction_groups[inter_type].items():
@@ -102,7 +102,7 @@ def __main__():
             # assign each interaction type directly into the block.
             # Need to do this way to ensure, e.g. bonds/constraints are written properly
             for inter_type, interactions in fitter.interactions_dict.items():
-                block.interactions[inter_type] = interactions
+                block.interactions[inter_type] = interactions + remainders.get(inter_type, [])
 
             # make plots if we want to
             if args.plots:

--- a/fast_forward/itp_to_ag.py
+++ b/fast_forward/itp_to_ag.py
@@ -4,6 +4,7 @@ groups of an MDAnalysis Universe.
 """
 import numpy as np
 from collections import defaultdict
+from vermouth.molecule import Interaction
 
 def find_indices(universe, atoms, molname, natoms):
     """
@@ -26,6 +27,7 @@ def itp_to_ag(block, mol_name, universe):
     grouped indices corresponding to the atoms in universe.
     """
     indices_dict = defaultdict(dict)
+    remainders = defaultdict(list)
     for inter_type in block.interactions:
         for inter in block.interactions[inter_type]:
             atoms = inter.atoms
@@ -34,5 +36,7 @@ def itp_to_ag(block, mol_name, universe):
                 indices = find_indices(universe, atoms, mol_name, natoms=len(block.nodes))
                 old_indices = indices_dict[inter_type].get(group, [])
                 indices_dict[inter_type][group] = indices + old_indices
+            else:
+                remainders[inter_type].extend([Interaction(inter.atoms, inter.parameters, meta={})])
 
-    return indices_dict
+    return indices_dict, remainders


### PR DESCRIPTION
resolves #37.

If a directive contains both commented and uncommented interactions, the uncommented ones are currently lost. This is because we completely overwrite the interactions in each block. Here we retain uncommented interactions, which then get combined with fitted ones when the directive is overwritten.

This feature will be useful for fragment based parameterisation. If a molecule is comprised of several subfragments which may already be parameterised, and what's needed is the links between the fragments, a topology could be drafted containing uncommented (and therefore unmodified) fragment parameters, mixed with commented inter-fragment parameters, which can then be analysed/fitted