### PR TITLE
Fix addition of interaction to block for systems of multiple molecules

### DIFF
--- a/bin/ff_assess
+++ b/bin/ff_assess
@@ -97,7 +97,7 @@ def __main__():
                         'dihedrals': {}}
         # loop over molecules
         for molname, block in ff.blocks.items():
-            interaction_groups, _ = itp_to_ag(block, molname, u)
+            interaction_groups, _ , _= itp_to_ag(block, molname, u)
             for inter_type in ['bonds', 'angles', 'dihedrals']:
                 for group_name, pair_idxs in interaction_groups[inter_type].items():
                     distr = interaction_distribution(u, inter_type, pair_idxs)

--- a/bin/ff_inter
+++ b/bin/ff_inter
@@ -110,7 +110,7 @@ def __main__():
             # calculate distributions for interaction
             if not args.itp_only:
                 guess_interactions(block)
-            interaction_groups, initial_parameters = itp_to_ag(block, molname, u)
+            interaction_groups, initial_parameters, block_indices = itp_to_ag(block, molname, u)
             for inter_type in RECOGNISED_INTERACTIONS:
                 for group_name, pair_idxs in interaction_groups[inter_type].items():
                     # make sure we know which kind of virtual site we're dealing with
@@ -120,7 +120,7 @@ def __main__():
                                                      args.prefix, args.distribution_data)
 
                     # fit the interactions
-                    fitter.fit_interaction(distr, pair_idxs, group_name, inter_type,
+                    fitter.fit_interaction(distr, block_indices[inter_type][group_name], group_name, inter_type,
                                            vs_constructors)
 
                     if inter_type in VIRTUALSITE_TYPES:

--- a/fast_forward/itp_to_ag.py
+++ b/fast_forward/itp_to_ag.py
@@ -63,6 +63,7 @@ def itp_to_ag(block, mol_name, universe):
 
     indices_dict = defaultdict(dict)
     initial_parameters = defaultdict(dict)
+    block_indices = defaultdict(dict)
     for inter_type in block.interactions:
         for inter in block.interactions[inter_type]:
             atoms = inter.atoms
@@ -74,7 +75,11 @@ def itp_to_ag(block, mol_name, universe):
                                        match_values,
                                        natoms=len(block.nodes))
                 old_indices = indices_dict[inter_type].get(group, [])
+                old_block_indices = block_indices[inter_type].get(group, [])
+
                 indices_dict[inter_type][group] = indices + old_indices
                 initial_parameters[inter_type][group] = inter.parameters
 
-    return indices_dict, initial_parameters
+                block_indices[inter_type][group] = [atoms] + old_block_indices
+
+    return indices_dict, initial_parameters, block_indices


### PR DESCRIPTION
Identify indices of atom groups in the block using `itp_to_ag`. When adding interactions to block after fitting, add using block indices *not* pair indices corresponding to tpr indexing