### PR TITLE
[3.5] fix small bugs in ff_inter and ff_map

### DIFF
--- a/bin/ff_inter
+++ b/bin/ff_inter
@@ -118,7 +118,7 @@ def __main__():
             # check for virtualsites
             vs_constructors = virtualsite_atoms(block)
             # calculate distributions for interaction
-            if not args.itp_mode:
+            if args.itp_mode == 'all':
                 guess_interactions(block)
             interaction_groups, initial_parameters, block_indices = interaction_mapper.get_interactions_group(molname, args.itp_mode)
 

--- a/bin/ff_map
+++ b/bin/ff_map
@@ -189,11 +189,6 @@ def main():
                         n_atoms=len(cg_universe.atoms)) as first_frame:
                         first_frame.box = init_universe.dimensions if isinstance(init_universe.dimensions, np.ndarray) else np.array([7.0, 7.0, 7.0])
                         first_frame.write(cg_beads) 
-        cg_universe.atoms.positions = cg_universe.trajectory.coordinate_array[0]
-        cg_beads = cg_universe.atoms
-        cg_universe.atoms.dimensions = init_universe.atoms.dimensions
-        with mda.Writer(args.outpath, n_atoms=len(cg_universe.atoms)) as mapped:
-            mapped.write(cg_beads)
 
 if __name__ == '__main__':
     main()

--- a/fast_forward/itp_parser_sub.py
+++ b/fast_forward/itp_parser_sub.py
@@ -128,8 +128,10 @@ def guess_interactions(block):
     """
 
     # clear any existing angles and dihedrals to prevent duplicates
-    del block.interactions['angles']
-    del block.interactions['dihedrals']
+    if block.interactions.get('angles'):
+        del block.interactions['angles']
+    if block.interactions.get('dihedrals'):
+        del block.interactions['dihedrals']
 
     block.make_edges_from_interactions()
 
@@ -147,4 +149,3 @@ def guess_interactions(block):
             comment = '_'.join([block.nodes[atom]['atomname'] for atom in i])
             block.add_interaction('dihedrals', atoms=i,
                                   parameters=['1', '10', '1', '1'], meta={'version': 0, 'comment': comment})
-


### PR DESCRIPTION
- ff_inter didn't perform interaction guessing correctly
- interaction guessing requires interactions to be present before deleting
- ff_map had some strange overwriting behaviour that meant sometimes xtc file got incorrectly overwritten with a single frame