### PR TITLE
[4.5] fix small bugs for virtual site construction and dihedral detection

### DIFF
--- a/fast_forward/interaction_fit.py
+++ b/fast_forward/interaction_fit.py
@@ -27,6 +27,7 @@ def _is_part_of_dihedral(angle_atoms, dihedrals):
     bool
         True if angle is part of a dihedral, False otherwise
     """
+    match = False
     for dih in dihedrals:
         match = (
             np.array_equal(angle_atoms, dih[0:3]) or
@@ -109,6 +110,7 @@ class InteractionFitter:
         max_dihedrals: int
             maximum number of dihedrals to fit proper dihedrals with
         '''
+        self.__dihedrals = None
         self.precision = precision
         self.temperature = temperature
         self.kb = constants["Boltzmann_constant"]
@@ -348,7 +350,7 @@ class InteractionFitter:
 
     @dihedrals.setter
     def dihedrals(self, interaction_groups):
-        self.__dihedrals =[dih for key in interaction_groups['dihedrals'] for dih in interaction_groups['dihedrals'][key]]
+        self.__dihedrals = [dih for key in interaction_groups['dihedrals'] for dih in interaction_groups['dihedrals'][key]]
 
     def fit_to_gmx(self, inter_type, group_name, atoms, vs_constructors):
 
@@ -396,7 +398,9 @@ class InteractionFitter:
                 if float(center) < 160: # empirically derived. For theta_0 > 160, significant ptl energy for type 10 at equilibrium, so enforce type 1.
                     func_type_out = 10
                 else:
-                    print(f"WARNING: Angle {group_name} is part of a dihedral with equilibrium angle {center:.1f}°. For theta_0 > 160°, the system may have high potential even energy at equilibrium. This might cause instabilities.")
+                    print((f"WARNING: Angle {group_name} is part of a dihedral with equilibrium angle {center:.1f}°. "
+                           f"For theta_0 > 160°, the system may have high potential even energy at equilibrium. "
+                           f"This might cause instabilities."))
                     func_type_out = 10
             else:
                 func_type_out = 1

--- a/fast_forward/virtual_site_mass.py
+++ b/fast_forward/virtual_site_mass.py
@@ -31,6 +31,7 @@ def mass_redistribution(block, pair_idx):
 
                 if not isclose(current_mass, expected_new_mass):
                     block.nodes[node]["mass"] = expected_new_mass
+                    block.nodes[node]["charge"] = block.nodes[node].get("charge", "0.0")
                 else:
                     reassign.append(True)
 


### PR DESCRIPTION
- for virtual site mass redistribution, need to write in charge explicitly if not given, otherwise gromacs gets upset
- _is_part_of_dihedral returned nothing if dihedrals is empty. Set match = False explicitly to avoid this case.