### PR TITLE
Fix angle shift in dihedral fitting

### DIFF
--- a/fast_forward/interaction_fit.py
+++ b/fast_forward/interaction_fit.py
@@ -244,7 +244,8 @@ class InteractionFitter:
 
         # take care of periodic effects for improper dihedrals
         x_gauss = np.linspace(-2*np.pi, 2*np.pi, 720)
-        y_gauss = np.tile(y, 2)
+        # roll by half a period so the tiled copies align with x_gauss
+        y_gauss = np.roll(np.tile(y, 2), y.size // 2)
 
         # first try fitting a gaussian to the data in case we have an improper dihedral
         gaussian_result = _gaussian_fitter(x_gauss[120:-120],
@@ -311,8 +312,8 @@ class InteractionFitter:
                                                                                                             x)}
 
         else:
-            # transform the centre back into the correct domain after fitting to account for periodicity.
-            c0 = (gaussian_result.params['center'].value + (2*np.pi)) % (2*np.pi) - np.pi
+            # wrap the fitted centre into [-pi, pi]
+            c0 = ((gaussian_result.params['center'].value + np.pi) % (2*np.pi)) - np.pi
 
             center = np.round(c0, self.precision)
             sigma = np.round((self.kb * self.temperature) / ((gaussian_result.params['sigma']) ** 2), self.precision)


### PR DESCRIPTION
The improper-dihedral branch of `_dihedrals_fitter` builds a doubled, tiled distribution to handle periodicity. However, the used `np.tile(y, 2)` places the copies half a period ($\pi$) out of step with `x_gauss`, so a peak at angle $\theta$ ends up at $\theta-\pi$ in the tiled data. Since the result is correctly wrapped back in [line 315](https://github.com/Martini-Force-Field-Initiative/fast_forward/blob/718ce2de78b82285855707cd41a4c1983167cdfd/fast_forward/interaction_fit.py#L315), this itself is not really a problem. However, the Gaussian fit is still seeded at the unshifted peak `x[y.argmax()]`, which then lands $\approx 180^\circ$ away. Depending on the distribution being fitted, this can result in a failed fitting with an $\theta_0$ value far away from the actual maximum of the distribution.

My patch rolls the tiled data by half its length (`np.roll(np.tile(y, 2), y.size // 2)`) so the copies align with `x_gauss` and the peak stays at its true angle . This change also requires to change the back-shifting/center recovery from [line 315](https://github.com/Martini-Force-Field-Initiative/fast_forward/blob/718ce2de78b82285855707cd41a4c1983167cdfd/fast_forward/interaction_fit.py#L315).

An alternative one-line fix is to keep the tiling and instead seed the Gaussian at the shifted location `(x[y.argmax()] % (2 * pi)) - pi`, letting the existing recovery formula unshift it. That works equally well, but is a bit more confusing since there would be a hidden offset in the angle.